### PR TITLE
0.0.2: base58, memzero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.0.2
+
+- Changed `bip32_serialze` str_len to a pointer which returns the final length of the
+  base58-encoded out string.
+- Added some precautionary `sodium_memzero()` calls.
+- Made `bip32_b58_encode()` and `bip32_b58_decode()` a public part of the API.

--- a/bip32.h
+++ b/bip32.h
@@ -1,3 +1,7 @@
+/**
+ * This API is generally designed to mimic the libsecp256k1 library, in terms of
+ * argument order and return conventions.
+ */
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -60,11 +64,14 @@ int bip32_derive_from_str(bip32_key *target, const char* source, const char* pat
  */
 int bip32_derive(bip32_key *target, const char* path);
 
-/** Serialize a BIP32 key to its base58 string representation.
+/** Serialize a BIP32 key to its base58 string representation. Writes the resulting
+ * string to `str`, and the length of the resulting string to `str_len`.
+ *
+ * `str_len` must initially be set to the maximum length of the `str` buffer.
  *
  * Returns 1 if successful.
  */
-int bip32_serialize(const bip32_key *key, char *str, size_t str_len);
+int bip32_serialize(const bip32_key *key, char *str, size_t* str_len);
 
 /** Deserialize a BIP32 key from its base58 string representation.
  *
@@ -105,6 +112,18 @@ void bip32_hmac_sha512(
     const unsigned char* msg,
     size_t msg_len
 );
+
+/** Encode some bytes to a base58 string.
+ *
+ * Returns true if successful.
+ */
+bool bip32_b58_encode(char* str_out, size_t* out_size, const unsigned char* data, size_t data_size);
+
+/** Decode some bytes from a base58 string.
+ *
+ * Returns true if successful.
+ */
+bool bip32_b58_decode(unsigned char* bin_out, size_t* out_size, const char* str_in, size_t str_size);
 
 #ifdef __cplusplus
 }

--- a/examples/cli.c
+++ b/examples/cli.c
@@ -15,7 +15,8 @@ int main(int argc, char *argv[]) {
        return 1;
    }
 
-   if (!bip32_serialize(&key, serialized, sizeof(serialized))) {
+   size_t out_size;
+   if (!bip32_serialize(&key, serialized, &out_size)) {
        fprintf(stderr, "Serialization failed\n");
        return 1;
    }

--- a/examples/py/bindings.py
+++ b/examples/py/bindings.py
@@ -3,9 +3,17 @@ import os
 from functools import lru_cache
 from pathlib import Path
 from ctypes import (
-    c_uint8, c_uint32, c_size_t, c_char_p, c_ubyte, c_void_p,
-    Structure, Union, POINTER, create_string_buffer
-)
+    c_uint8,
+    c_uint32,
+    c_size_t,
+    c_char_p,
+    c_ubyte,
+    c_void_p,
+    Structure,
+    Union,
+    POINTER,
+    create_string_buffer,
+    byref)
 
 
 @lru_cache
@@ -20,7 +28,9 @@ def get_bip32_module():
     bip32_lib.bip32_init.argtypes = [POINTER(BIP32Key)]
     bip32_lib.bip32_init.restype = None
 
-    bip32_lib.bip32_derive_from_seed.argtypes = [POINTER(BIP32Key), POINTER(c_ubyte), c_size_t, c_char_p]
+    bip32_lib.bip32_derive_from_seed.argtypes = [
+        POINTER(BIP32Key), POINTER(c_ubyte), c_size_t, c_char_p
+    ]
     bip32_lib.bip32_derive_from_seed.restype = ctypes.c_int
 
     bip32_lib.bip32_derive_from_str.argtypes = [POINTER(BIP32Key), c_char_p, c_char_p]
@@ -29,7 +39,9 @@ def get_bip32_module():
     bip32_lib.bip32_derive.argtypes = [POINTER(BIP32Key), c_char_p]
     bip32_lib.bip32_derive.restype = ctypes.c_int
 
-    bip32_lib.bip32_serialize.argtypes = [POINTER(BIP32Key), c_char_p, c_size_t]
+    bip32_lib.bip32_serialize.argtypes = [
+        POINTER(BIP32Key), c_char_p, POINTER(c_size_t)
+    ]
     bip32_lib.bip32_serialize.restype = ctypes.c_bool
 
     bip32_lib.bip32_deserialize.argtypes = [POINTER(BIP32Key), c_char_p, c_size_t]
@@ -38,14 +50,22 @@ def get_bip32_module():
     bip32_lib.bip32_get_public.argtypes = [POINTER(BIP32Key), POINTER(BIP32Key)]
     bip32_lib.bip32_get_public.restype = ctypes.c_int
 
+    bip32_lib.bip32_b58_encode.argtypes = [
+        c_char_p, POINTER(c_size_t), POINTER(c_ubyte), c_size_t
+    ]
+    bip32_lib.bip32_b58_encode.restype = ctypes.c_bool
+
+    bip32_lib.bip32_b58_decode.argtypes = [
+        POINTER(c_ubyte), POINTER(c_size_t), c_char_p, c_size_t
+    ]
+    bip32_lib.bip32_b58_decode.restype = ctypes.c_bool
+
     return bip32_lib
 
 
 class KeyUnion(Union):
-    _fields_ = [
-        ('privkey', c_uint8 * 32),
-        ('pubkey', c_uint8 * 33)
-    ]
+    _fields_ = [('privkey', c_uint8 * 32), ('pubkey', c_uint8 * 33)]
+
 
 class BIP32Key(Structure):
     _fields_ = [
@@ -65,6 +85,7 @@ class BIP32Key(Structure):
 
 
 class BIP32:
+
     def __init__(self):
         self.key = BIP32Key()
         self.bip32_lib = get_bip32_module()
@@ -80,7 +101,9 @@ class BIP32:
 
     def serialize(self):
         buf = create_string_buffer(200)  # Standard BIP32 serialization length
-        if not self.bip32_lib.bip32_serialize(self.key, buf, len(buf)):
+        out_len = c_size_t(len(buf))
+
+        if not self.bip32_lib.bip32_serialize(self.key, buf, byref(out_len)):
             raise ValueError("Serialization failed")
         return buf.value.decode()
 
@@ -106,7 +129,8 @@ def derive(source: str, path: str = 'm') -> BIP32:
 
     """
     b = BIP32()
-    if not get_bip32_module().bip32_derive_from_str(b.key, source.encode(), path.encode()):
+    if not get_bip32_module().bip32_derive_from_str(
+            b.key, source.encode(), path.encode()):
         raise ValueError("failed")
     return b
 
@@ -115,6 +139,35 @@ def derive_from_seed(seed: bytes, path: str = 'm') -> BIP32:
     b = BIP32()
     c_seed = ctypes.c_char_p(seed)
     seed_ptr = ctypes.cast(c_seed, POINTER(c_ubyte))
-    if not get_bip32_module().bip32_derive_from_seed(b.key, seed_ptr, len(seed), path.encode()):
+    if not get_bip32_module().bip32_derive_from_seed(
+            b.key, seed_ptr, len(seed), path.encode()):
         raise ValueError("failed")
     return b
+
+
+def b58_encode(inp: bytes) -> str:
+    data_len = len(inp)
+    data_arr = (c_ubyte * data_len)(*inp)
+
+    out_size = c_size_t(data_len * 2)
+    str_out = ctypes.create_string_buffer(out_size.value)
+
+    if not get_bip32_module().bip32_b58_encode(
+            str_out, byref(out_size), data_arr, data_len):
+        raise ValueError("base58 encoding failed")
+
+    return str_out.value[:out_size.value].decode('utf-8')
+
+
+def b58_decode(in_str: str) -> bytes:
+    str_bytes = c_char_p(in_str.encode('utf-8'))
+    str_len = len(in_str)
+
+    out_size = c_size_t(str_len * 2)
+    bin_out = (c_ubyte * out_size.value)()
+
+    if not get_bip32_module().bip32_b58_decode(
+            bin_out, byref(out_size), str_bytes, str_len):
+        raise ValueError("base58 decoding failed")
+
+    return bytes(bin_out[-out_size.value:])

--- a/test/test.c
+++ b/test/test.c
@@ -50,8 +50,10 @@ void test_vector_1(void) {
         return;
     }
 
+    size_t out_size = 200;
+
     // Test private key
-    bip32_serialize(&master, str, sizeof(str));
+    bip32_serialize(&master, str, &out_size);
     printf("  Private:  %s\n", str);
     printf("  Expected: xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi\n");
     if (strcmp(str, "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi") != 0) {
@@ -62,7 +64,7 @@ void test_vector_1(void) {
     // Test public key
     bip32_key pub;
     bip32_get_public(&pub, &master);
-    bip32_serialize(&pub, str, sizeof(str));
+    bip32_serialize(&pub, str, &out_size);
     printf("  Public:   %s\n", str);
     printf("  Expected: xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8\n");
     if (strcmp(str, "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8") != 0) {
@@ -77,12 +79,12 @@ void test_vector_1(void) {
         return;
     }
     
-    bip32_serialize(&child, str, sizeof(str));
+    bip32_serialize(&child, str, &out_size);
     printf("  Private:  %s\n", str);
     printf("  Expected: xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7\n");
 
     bip32_get_public(&pub, &child);
-    bip32_serialize(&pub, str, sizeof(str));
+    bip32_serialize(&pub, str, &out_size);
     printf("  Public:   %s\n", str);
     printf("  Expected: xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw\n");
 
@@ -93,12 +95,12 @@ void test_vector_1(void) {
         return;
     }
 
-    bip32_serialize(&master, str, sizeof(str));
+    bip32_serialize(&master, str, &out_size);
     printf("  Private:  %s\n", str);
     printf("  Expected: xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs\n");
 
     bip32_get_public(&pub, &master);
-    bip32_serialize(&pub, str, sizeof(str));
+    bip32_serialize(&pub, str, &out_size);
     printf("  Public:   %s\n", str);
     printf("  Expected: xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ\n");
 


### PR DESCRIPTION
## 0.0.2

- Changed `bip32_serialze` str_len to a pointer which returns the final length of the
  base58-encoded out string.
- Added some precautionary `sodium_memzero()` calls.
- Made `bip32_b58_encode()` and `bip32_b58_decode()` a public part of the API.